### PR TITLE
Add jupyterlab=3 to the Binder environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: voila
 channels:
   - conda-forge
 dependencies:
+  - jupyterlab=3
   - ipyvolume
   - bqplot
   - scipy


### PR DESCRIPTION
To make it easier to try the JupyterLab preview extension on Binder.

Can be tested with:

https://mybinder.org/v2/gh/jtpio/voila/lab-3-binder?urlpath=lab